### PR TITLE
Removed the .hide() method on my sign up field

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -5,7 +5,6 @@ const store = require('../store')
 const signUpSuccess = function () {
   $('#myModalTwo').modal('show')
   $('#message').empty()
-  $('.unauthenticated').hide()
   $('.sign-in-field').show()
   $('form').trigger('reset')
 }


### PR DESCRIPTION
Now, sign up fields do not disappear upon successful sign up